### PR TITLE
fix: vignette template resolves package root from vignettes/ (#12)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: c4r
 Title: Create C4 Architecture Diagrams
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     person("Fabian", "Distler", , "example@email.com", role = c("aut", "cre"))
 Description: Provides functions to create C4 architecture diagrams

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # c4r (development version)
 
+## Bug fixes
+
+* `use_c4r_vignette()` now generates a vignette that builds cleanly under
+  `devtools::build_vignettes()`. The bundled template previously called
+  `c4_from_package(".")`, which failed because knitr knits vignettes with
+  the working directory set to `vignettes/` (#12).
+
 ## R-package toolchain integration
 
 * New `use_c4r()` family of `usethis`-style scaffolding helpers:

--- a/inst/templates/architecture.Rmd
+++ b/inst/templates/architecture.Rmd
@@ -17,7 +17,7 @@ This page renders a C4 diagram of the package architecture using
 ## From package metadata
 
 ```{r}
-c4r::c4_from_package(".") |> c4r::build_context()
+c4r::c4_from_package("..") |> c4r::build_context()
 ```
 
 ## From a starter template

--- a/tests/testthat/test-use.R
+++ b/tests/testthat/test-use.R
@@ -32,6 +32,10 @@ test_that("use_c4r_vignette writes a vignette", {
     expect_true(file.exists(out))
     contents <- readLines(out)
     expect_true(any(grepl("monolith", contents, fixed = TRUE)))
+    # Vignettes knit with wd = vignettes/, so the template must reach the
+    # package root via ".." rather than ".". Regression guard for #12.
+    expect_true(any(grepl('c4_from_package("..")', contents, fixed = TRUE)))
+    expect_false(any(grepl('c4_from_package(".")', contents, fixed = TRUE)))
   })
 })
 


### PR DESCRIPTION
## Summary

- Fix the bundled `inst/templates/architecture.Rmd` so vignettes scaffolded by `use_c4r_vignette()` build cleanly under `devtools::build_vignettes()`.
- Replace `c4r::c4_from_package(".")` with `c4r::c4_from_package("..")`. knitr knits a vignette with `wd = vignettes/`, so `"."` was pointing at `vignettes/` (no `DESCRIPTION`) and `c4_from_package()` aborted with `No 'DESCRIPTION' found at '.'.`.
- Add a regression guard in `tests/testthat/test-use.R` asserting the generated vignette references `c4_from_package("..")` (and not `c4_from_package(".")`).
- Add a bug-fix entry to `NEWS.md`.

Closes #12.

## Test plan

- [x] `inst/templates/architecture.Rmd` now contains `c4r::c4_from_package("..") |> c4r::build_context()`.
- [x] Reproduced the original failure: from `wd = vignettes/`, `c4_from_package(".")` aborts with the exact issue-12 error.
- [x] Verified the fix: from `wd = vignettes/`, `c4_from_package("..")` returns a `c4_builder` for the parent package.
- [x] Extended `test_that("use_c4r_vignette writes a vignette", ...)` passes; new assertions guard against the path regression.
- [ ] CI (R-CMD-check, pkgdown) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8GPvsoR6nQrzcSqPqiHvp)_